### PR TITLE
[API-History-issue#2] history routes, controller 수정, API URL path 수정

### DIFF
--- a/arsns/controllers/history.js
+++ b/arsns/controllers/history.js
@@ -126,8 +126,8 @@ module.exports = {
     },
 
     getHistory : async(req, res) => {
-        const myid = req.params.myid;
-        const yourid = req.params.yourid;
+        const myid = req.params.my-id;
+        const yourid = req.params.your-id;
         const bssid1 = req.params.bssid1;
         const bssid2 = req.params.bssid2;
         // const{location} = req.body;
@@ -156,24 +156,9 @@ module.exports = {
             return res.status(statusCode.OK).send(util.success(statusCode.OK, resMessage.GET_HISTORY_SUCCESS, result));
     },
 
-    getFriendHistory : async(req, res) => {
-        const myId = req.params.myId;
-        const friendId = req.params.friendId;
-        if(!myId || !friendId){
-            res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
-            return;
-        }
-
-        let result = await HistoryModel.getFriendHistory(myId, friendId);
-        if(result.length == 0){
-            res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.GET_HISTORY_FAIL));
-        }
-        return res.status(statusCode.OK).send(util.success(statusCode.OK, resMessage.GET_HISTORY_SUCCESS, result));
-    },
-
     likeHistory : async(req, res) =>{
-        const historyIdx = req.params.historyIdx;
-        const userIdx = req.params.userIdx;
+        const historyIdx = req.params.history-idx;
+        const userIdx = req.params.user-idx;
         if(!userIdx || !historyIdx){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;
@@ -210,8 +195,8 @@ module.exports = {
     },
 
     deleteHistory : async(req, res) =>{
-        const historyIdx = req.params.historyIdx;
-        const userIdx = req.params.userIdx;
+        const historyIdx = req.params.history-idx;
+        const userIdx = req.params.user-idx;
         if(!userIdx || !historyIdx){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;
@@ -237,8 +222,8 @@ module.exports = {
     },
 
     deleteComment : async(req, res) =>{
-        const userIdx = req.params.userIdx;
-        const commentIdx = req.params.commentIdx;
+        const userIdx = req.params.user-idx;
+        const commentIdx = req.params.comment-idx;
         if(!userIdx || !commentIdx){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;
@@ -251,7 +236,7 @@ module.exports = {
     },
 
     getComment : async(req, res) =>{
-        const historyIdx = req.params.historyIdx;
+        const historyIdx = req.params.history-idx;
         if(!historyIdx){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;
@@ -264,7 +249,7 @@ module.exports = {
     },
     
     tagList : async(req, res) =>{
-        const myid = req.params.myid;
+        const myid = req.params.my-id;
         if(!myid){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;
@@ -279,8 +264,8 @@ module.exports = {
     },
 
     detailHistory : async(req, res) =>{
-        const myid = req.params.myid;
-        const historyIdx = req.params.historyIdx;
+        const myid = req.params.my-id;
+        const historyIdx = req.params.history-idx;
         if(!myid || !historyIdx){
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.NULL_VALUE));
             return;

--- a/arsns/routes/history/index.js
+++ b/arsns/routes/history/index.js
@@ -7,15 +7,14 @@ const upload = require('../../modules/multer');
 //     dest: 'upload/'
 // });
 
-router.post('/addHistory', upload.array('content',1), historyController.addHistory);
-router.get('/getHistory/:myid/:yourid/:bssid1/:bssid2', historyController.getHistory);
-router.get('/getFriendHistory/:myId/:friendId', historyController.getFriendHistory);
-router.put('/like/:userIdx/:historyIdx', historyController.likeHistory);
-router.delete('/deleteHistory/:userIdx/:historyIdx', historyController.deleteHistory);
-router.post('/addComment', historyController.addComment);
-router.delete('/deleteComment/:userIdx/:commentIdx', historyController.deleteComment);
-router.get('/getComment/:historyIdx', historyController.getComment);
-router.get('/tagList/:myid', historyController.tagList);
-router.get('/:myid/:historyIdx',historyController.detailHistory);
+router.post('/v1/histories', upload.array('content',1), historyController.addHistory);
+router.get('/v1/histories/:my-id/:your-id/:bssid1/:bssid2', historyController.getHistory);
+router.get('/v1/histories/:my-id/:history-idx',historyController.detailHistory);
+router.delete('/v1/histories/:user-idx/:history-idx', historyController.deleteHistory);
+router.post('/v1/comments', historyController.addComment);
+router.delete('/v1/comments/:user-idx/:comment-idx', historyController.deleteComment);
+router.get('/v1/comments/:history-idx', historyController.getComment);
+router.get('/v1/tags/:my-id', historyController.tagList);
+router.put('/v1/likes/:user-idx/:history-idx', historyController.likeHistory);
 
 module.exports = router;


### PR DESCRIPTION
## 개요
history부분 API URL path 수장

## 작업사항
history routes, controller 수정

## 변경로직
### 변경전
- 단수사용
- 동사사용
- 대문자 사용
- 행위를 path상에 명시
 
### 변경후
- 복수로 변경
- 동사대신 명사로 변경
- 대문자사용 대신 하이픈사용(ex: commentIdx -> comment-idx)
- 행위는 HTTP Method로 표현, path상에서 표현하지 않음(ex: ~/addHistory에서 add는 행위를 나타냄. -> 삭제)

## 사용방법
N/A
## 기타
N/A